### PR TITLE
Added a new feature: low battery warning sound. This plays a file

### DIFF
--- a/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/Localization/Strings.Designer.cs
+++ b/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/Localization/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace XB1ControllerBatteryIndicator.Localization {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Strings {
@@ -120,6 +120,33 @@ namespace XB1ControllerBatteryIndicator.Localization {
         public static string ContextMenu_Language {
             get {
                 return ResourceManager.GetString("ContextMenu_Language", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Low battery warning sound.
+        /// </summary>
+        public static string ContextMenu_LowBatteryWarningSound {
+            get {
+                return ResourceManager.GetString("ContextMenu_LowBatteryWarningSound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enabled.
+        /// </summary>
+        public static string ContextMenu_LowBatteryWarningSound_Enabled {
+            get {
+                return ResourceManager.GetString("ContextMenu_LowBatteryWarningSound_Enabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Repeat on loop.
+        /// </summary>
+        public static string ContextMenu_LowBatteryWarningSound_Loop_Enabled {
+            get {
+                return ResourceManager.GetString("ContextMenu_LowBatteryWarningSound_Loop_Enabled", resourceCulture);
             }
         }
         

--- a/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/Localization/Strings.de.resx
+++ b/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/Localization/Strings.de.resx
@@ -186,4 +186,13 @@
   <data name="ContextMenu_Language" xml:space="preserve">
     <value>Sprache</value>
   </data>
+  <data name="ContextMenu_LowBatteryWarningSound" xml:space="preserve">
+    <value>schwacher Batteriewarnungton</value>
+  </data>
+  <data name="ContextMenu_LowBatteryWarningSound_Enabled" xml:space="preserve">
+    <value>Eingeschaltet</value>
+  </data>
+  <data name="ContextMenu_LowBatteryWarningSound_Loop_Enabled" xml:space="preserve">
+    <value>Loop-Wiedergabe</value>
+  </data>
 </root>

--- a/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/Localization/Strings.es.resx
+++ b/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/Localization/Strings.es.resx
@@ -118,81 +118,81 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NewVersionAvailable_Title" xml:space="preserve">
-    <value>New version available</value>
+    <value>Nueva versión disponible</value>
   </data>
   <data name="NewVersionAvailable_Body" xml:space="preserve">
-    <value>A new version of {0} is available. Do you want to open the Homepage?</value>
+    <value>Una nueva versión de {0} está disponible. ¿Quieres abrir la página de inicio?</value>
   </data>
   <data name="ContextMenu_AutoStart" xml:space="preserve">
-    <value>Start with Windows</value>
+    <value>Arrancar con Windows</value>
   </data>
   <data name="ContextMenu_Exit" xml:space="preserve">
-    <value>Exit</value>
+    <value>Salir</value>
   </data>
   <data name="ContextMenu_UpdateCheck" xml:space="preserve">
-    <value>Check for new version on start</value>
+    <value>Buscar nueva versión en el arranque</value>
   </data>
   <data name="ToolTip_NoController" xml:space="preserve">
-    <value>No controller detected</value>
+    <value>Ningún mando ha sido detectado</value>
   </data>
   <data name="ToolTip_WaitingForData" xml:space="preserve">
-    <value>Controller {0} - Found but still waiting for battery data...</value>
+    <value>Mando {0} - Detectado pero todavía esperando los datos de la batería...</value>
   </data>
   <data name="ToolTip_Unknown" xml:space="preserve">
-    <value>Controller {0} - Unknown</value>
+    <value>Mando {0} - Desconocido</value>
   </data>
   <data name="ToolTip_Wired" xml:space="preserve">
-    <value>Controller {0} - Wired</value>
+    <value>Mando {0} - Cableado</value>
   </data>
   <data name="ToolTip_Wireless" xml:space="preserve">
-    <value>Controller {0} - Battery level: {1}</value>
+    <value>Mando {0} - Nivel de batería: {1}</value>
   </data>
   <data name="Toast_Title" xml:space="preserve">
-    <value>Controller {0} low battery warning</value>
+    <value>Advertencia de batería baja del mando {0}</value>
   </data>
   <data name="Toast_Text" xml:space="preserve">
-    <value>Battery of controller {0} is (almost) empty.</value>
+    <value>La batería del mando {0} está (casi) vacía.</value>
   </data>
   <data name="Toast_Text2" xml:space="preserve">
-    <value>(Click on the Button to stop the reappearing of this warning.)</value>
+    <value>(Cliquea en el botón para evitar que esta advertencia reaparezca.)</value>
   </data>
   <data name="Toast_Dismiss" xml:space="preserve">
-    <value>Shut up!</value>
+    <value>¡Cállate la boca!</value>
   </data>
   <data name="BatteryLevel_Empty" xml:space="preserve">
-    <value>Empty</value>
+    <value>Vacío</value>
   </data>
   <data name="BatteryLevel_Full" xml:space="preserve">
-    <value>Full</value>
+    <value>Lleno</value>
   </data>
   <data name="BatteryLevel_Low" xml:space="preserve">
-    <value>Low</value>
+    <value>Bajo</value>
   </data>
   <data name="BatteryLevel_Medium" xml:space="preserve">
-    <value>Medium</value>
+    <value>Medio</value>
   </data>
   <data name="ControllerIndex_Four" xml:space="preserve">
-    <value>Four</value>
+    <value>Cuatro</value>
   </data>
   <data name="ControllerIndex_One" xml:space="preserve">
-    <value>One</value>
+    <value>Uno</value>
   </data>
   <data name="ControllerIndex_Three" xml:space="preserve">
-    <value>Three</value>
+    <value>Tres</value>
   </data>
   <data name="ControllerIndex_Two" xml:space="preserve">
-    <value>Two</value>
+    <value>Dos</value>
   </data>
   <data name="ContextMenu_Language" xml:space="preserve">
-    <value>Language</value>
+    <value>Lenguaje</value>
   </data>
   <data name="ContextMenu_LowBatteryWarningSound" xml:space="preserve">
-    <value>Low battery warning sound</value>
+    <value>Sonido de advertencia de batería baja</value>
   </data>
   <data name="ContextMenu_LowBatteryWarningSound_Enabled" xml:space="preserve">
-    <value>Enabled</value>
+    <value>Habilitado</value>
   </data>
   <data name="ContextMenu_LowBatteryWarningSound_Loop_Enabled" xml:space="preserve">
-    <value>Repeat on loop</value>
+    <value>Repetir en bucle</value>
   </data>
 </root>

--- a/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/Properties/Settings.Designer.cs
+++ b/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/Properties/Settings.Designer.cs
@@ -58,5 +58,35 @@ namespace XB1ControllerBatteryIndicator.Properties {
                 this["Language"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool LowBatteryWarningSound_Enabled
+        {
+            get
+            {
+                return ((bool) (this["LowBatteryWarningSound_Enabled"]));
+            }
+            set
+            {
+                this["LowBatteryWarningSound_Enabled"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool LowBatteryWarningSound_Loop_Enabled
+        {
+            get
+            {
+                return ((bool) (this["LowBatteryWarningSound_Loop_Enabled"]));
+            }
+            set
+            {
+                this["LowBatteryWarningSound_Loop_Enabled"] = value;
+            }
+        }
     }
 }

--- a/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/SystemTrayView.xaml
+++ b/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/SystemTrayView.xaml
@@ -43,6 +43,10 @@
                     </Style>
                 </MenuItem.ItemContainerStyle>
             </MenuItem>
+            <MenuItem Header="{my:Localization ContextMenu_LowBatteryWarningSound}" IsCheckable="False" ItemsSource="{Binding Path=LowBatteryWarningSoundOptions}" DisplayMemberPath="DisplayName">
+                <MenuItem x:Name="LowBatteryWarningSound_Enabled" Header="{my:Localization ContextMenu_LowBatteryWarningSound_Enabled}" IsCheckable="True" Click="LowBatteryWarningSound_Enabled_Click" IsChecked="{my:SettingBinding Path=LowBatteryWarningSound_Enabled}" />
+                <MenuItem x:Name="LowBatteryWarningSound_Loop_Enabled" Header="{my:Localization ContextMenu_LowBatteryWarningSound_Loop_Enabled}" IsCheckable="True" Click="LowBatteryWarningSound_Loop_Enabled_Click" IsChecked="{my:SettingBinding Path=LowBatteryWarningSound_Loop_Enabled}" />
+            </MenuItem>
             <Separator/>
             <MenuItem Header="{my:Localization ContextMenu_Exit}" cal:Message.Attach="ExitApplication" />
         </ContextMenu>

--- a/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/SystemTrayView.xaml.cs
+++ b/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/SystemTrayView.xaml.cs
@@ -131,7 +131,41 @@ namespace XB1ControllerBatteryIndicator
                 Properties.Settings.Default.Save();
             }
         }
+        //lowBatteryWarningSound_Enabled-checkbox was clicked
+        private void LowBatteryWarningSound_Enabled_Click(object sender, RoutedEventArgs e)
+        {
+            Debug.WriteLine("LowBatteryWarningSound_Enabled_Click");
 
+            bool lowBatteryWarningSound_Enabled = !Properties.Settings.Default.LowBatteryWarningSound_Enabled;
+            if (lowBatteryWarningSound_Enabled == false)
+            {
+                Properties.Settings.Default.LowBatteryWarningSound_Enabled = true;
+                Properties.Settings.Default.Save();
+            }
+            else
+            {
+                Properties.Settings.Default.LowBatteryWarningSound_Enabled = false;
+                Properties.Settings.Default.Save();
+            }
+        }
+        //lowBatteryWarningSound_Loop_Enabled-checkbox was clicked
+        private void LowBatteryWarningSound_Loop_Enabled_Click(object sender, RoutedEventArgs e)
+        {
+            Debug.WriteLine("LowBatteryWarningSound_Loop_Enabled_Click");
+
+            bool lowBatteryWarningSoundEnabled = !Properties.Settings.Default.LowBatteryWarningSound_Loop_Enabled;
+            if (lowBatteryWarningSoundEnabled == false)
+            {
+                Properties.Settings.Default.LowBatteryWarningSound_Loop_Enabled = true;
+                Properties.Settings.Default.Save();
+            }
+            else
+            {
+                Properties.Settings.Default.LowBatteryWarningSound_Loop_Enabled = false;
+                Properties.Settings.Default.Save();
+            }
+        }
+        //a language item checkbox was clicked
         private void LanguageItem_OnClick(object sender, RoutedEventArgs e)
         {
             var selectedLanguage = (CultureInfo)((FrameworkElement)e.OriginalSource).DataContext;

--- a/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator.csproj
+++ b/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator.csproj
@@ -214,6 +214,9 @@
       <LastGenOutput>Icons.Designer.cs</LastGenOutput>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="Localization\Strings.es.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="Localization\Strings.de.resx" />
     <EmbeddedResource Include="Localization\Strings.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>


### PR DESCRIPTION
named/located in "sounds/lowBatteryWarning.wav", located in the
program's root directory. If the file is missing, nothing happens (as
intended). The feature can be turned on/off via a tray menu setting.
The sound can be played once or on a loop (this can also be turned
on/off via a setting).

Added a Spanish translation

Added German translations for the new settings in the tray menu.
Beware though, my German is subpar so they are probably wrong/odd.
Deutsche Sprache, schwere Sprache :^)