### PR TITLE
Battery Level Popup - fixes

### DIFF
--- a/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/App.config
+++ b/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/App.config
@@ -71,8 +71,7 @@
       </setting>
       <setting name="PopupSettings" serializeAs="Xml">
         <value>
-          <SimpleBatteryPopupSettings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+          <SimpleBatteryPopupSettings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
             <Size>
               <Width>300</Width>
               <Height>60</Height>

--- a/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/Localization/Strings.ru.resx
+++ b/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/Localization/Strings.ru.resx
@@ -267,4 +267,25 @@
   <data name="PopupSettings_Title" xml:space="preserve">
     <value>Настройки всплывающего окна уровня заряда</value>
   </data>
+  <data name="ContextMenu_DisplayedIcons" xml:space="preserve">
+    <value>Отображаемые иконки</value>
+  </data>
+  <data name="ContextMenu_MinorUpdateCheck" xml:space="preserve">
+    <value>Проверять наличии незначительных обновлений (добавление языков)</value>
+  </data>
+  <data name="ContextMenu_ShowWiredControllers" xml:space="preserve">
+    <value>Проводной контроллер</value>
+  </data>
+  <data name="ContextMenu_ShowWirelessControllersWithKnownBatteryLevel" xml:space="preserve">
+    <value>Беспроводной контроллер с полученным уровнем заряда</value>
+  </data>
+  <data name="ContextMenu_ShowWirelessControllersWithUnknownBatteryLevel" xml:space="preserve">
+    <value>Беспроводной контроллен с неполученным уровнем заряда</value>
+  </data>
+  <data name="ContextMenu_UpdateCheckHeader" xml:space="preserve">
+    <value>Проверка обновлений</value>
+  </data>
+  <data name="NewMinorVersionAvailable_Body" xml:space="preserve">
+    <value>Доступно новое незначительное обновление (добавление языков) {0}. Перейти на домашнюю страницу?</value>
+  </data>
 </root>

--- a/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/SystemTrayViewModel.cs
+++ b/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/SystemTrayViewModel.cs
@@ -38,7 +38,7 @@ namespace XB1ControllerBatteryIndicator
 
 		private SoundPlayer _soundPlayer;
 
-		private readonly Controller[] _controllers = new[]
+		private readonly Controller[] _controllers =
 		{
 			new Controller(UserIndex.One), new Controller(UserIndex.Two), new Controller(UserIndex.Three),
 			new Controller(UserIndex.Four)
@@ -95,13 +95,7 @@ namespace XB1ControllerBatteryIndicator
 
             while(true)
             {
-                //Initialize controllers
-                var controllers = new[]
-                {
-                    new Controller(UserIndex.One), new Controller(UserIndex.Two), new Controller(UserIndex.Three),
-                    new Controller(UserIndex.Four)
-                };
-                var connectedControllers = controllers
+	            var connectedControllers = _controllers
                     .Where(controller => controller.IsConnected)
                     .Select(controller => (controller, battery: controller.GetBatteryInformation(BatteryDeviceType.Gamepad)));
                 TooltipText = string.Join("\n", connectedControllers.Select(controller =>

--- a/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/SystemTrayViewModel.cs
+++ b/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/SystemTrayViewModel.cs
@@ -411,21 +411,24 @@ namespace XB1ControllerBatteryIndicator
 			var batteryInfo = controller.GetBatteryInformation(BatteryDeviceType.Gamepad);
 			if (batteryInfo.BatteryType != BatteryType.Wired)
 			{
-				OnUIThread(() => ShowPopup(controller, batteryInfo));
+				ShowPopup(controller, batteryInfo);
 			}
 		}
 
 		private void ShowPopup(Controller controller, BatteryInformation batteryInformation)
 		{
-			if (_popup.IsOpen)
-				return;
+			OnUIThread(() =>
+			{
+				if (_popup.IsOpen)
+					return;
 
-			var viewModel = new SimpleBatteryLevelPopupViewModel(Settings.Default.PopupSettings,
-				string.Format(Strings.Popup_ControllerName, GetControllerIndexCaption(controller.UserIndex)),
-				string.Format(Strings.Popup_BatteryLevel, GetBatteryLevelCaption(batteryInformation.BatteryLevel)));
-			_popup.DataContext = viewModel;
+				var viewModel = new SimpleBatteryLevelPopupViewModel(Settings.Default.PopupSettings,
+					string.Format(Strings.Popup_ControllerName, GetControllerIndexCaption(controller.UserIndex)),
+					string.Format(Strings.Popup_BatteryLevel, GetBatteryLevelCaption(batteryInformation.BatteryLevel)));
+				_popup.DataContext = viewModel;
 
-			_popup.IsOpen = true;
+				_popup.IsOpen = true;
+			});
 		}
 	}
 }

--- a/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/SystemTrayViewModel.cs
+++ b/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/SystemTrayViewModel.cs
@@ -124,7 +124,7 @@ namespace XB1ControllerBatteryIndicator
                 foreach (var (controller, batteryInfo) in connectedControllers)
                 {
                     //check if toast was already triggered and battery is no longer empty...
-                    if (batteryInfo.BatteryLevel != BatteryLevel.Empty)
+                    if (batteryInfo.BatteryLevel != BatteryLevel.Empty && batteryInfo.BatteryType != BatteryType.Wired && batteryInfo.BatteryType != BatteryType.Disconnected)
                     {
                         if (toast_shown[numdict[$"{controller.UserIndex}"]] == true)
                         {
@@ -132,6 +132,8 @@ namespace XB1ControllerBatteryIndicator
                             toast_shown[numdict[$"{controller.UserIndex}"]] = false;
                             ToastNotificationManager.History.Remove($"Controller{controller.UserIndex}", "ControllerToast", APP_ID);
                         }
+
+                        _popupShown[controller.UserIndex] = new DateTime();
                     }
                 }
                 var shownControllers = connectedControllers.Where(connectedController =>
@@ -156,7 +158,7 @@ namespace XB1ControllerBatteryIndicator
                             break;
                     }
                     //when "empty" state is detected...
-                    if (batteryInfo.BatteryLevel == BatteryLevel.Empty)
+                    if (batteryInfo.BatteryLevel == BatteryLevel.Empty && batteryInfo.BatteryType != BatteryType.Wired && batteryInfo.BatteryType != BatteryType.Disconnected)
                     {
 	                    if (Settings.Default.LowBatteryToast_Enabled)
 	                    {

--- a/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/SystemTrayViewModel.cs
+++ b/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/SystemTrayViewModel.cs
@@ -46,6 +46,12 @@ namespace XB1ControllerBatteryIndicator
 
 		private readonly Popup _popup = new BatteryLevelPopupView();
 
+		private readonly Dictionary<UserIndex, DateTime> _popupShown = new Dictionary<UserIndex, DateTime>()
+		{
+			{UserIndex.One, new DateTime()}, {UserIndex.Two, new DateTime()}, {UserIndex.Three, new DateTime()},
+			{UserIndex.Four, new DateTime()}
+		};
+
 		public SystemTrayViewModel()
 		{
 			GetAvailableLanguages();
@@ -183,7 +189,13 @@ namespace XB1ControllerBatteryIndicator
 
                         if (Settings.Default.LowBatteryPopup_Enabled)
                         {
-	                        ShowPopup(currentController, batteryInfo);
+	                        var lastShownTime = _popupShown[currentController.UserIndex];
+	                        var currentTime = DateTime.Now;
+	                        if (currentTime - lastShownTime > TimeSpan.FromMinutes(5))
+	                        {
+								_popupShown[currentController.UserIndex] = currentTime;
+		                        ShowPopup(currentController, batteryInfo);
+							}
                         }
 					}
                     Thread.Sleep(5000);

--- a/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator.csproj
+++ b/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator.csproj
@@ -562,9 +562,9 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props'))" />
     <Error Condition="!Exists('..\packages\Resource.Embedder.2.1.1\build\Resource.Embedder.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Resource.Embedder.2.1.1\build\Resource.Embedder.props'))" />
-    <Error Condition="!Exists('..\packages\Fody.6.2.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.6.2.0\build\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\Fody.6.3.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.6.3.0\build\Fody.targets'))" />
   </Target>
-  <Import Project="..\packages\Fody.6.2.0\build\Fody.targets" Condition="Exists('..\packages\Fody.6.2.0\build\Fody.targets')" />
+  <Import Project="..\packages\Fody.6.3.0\build\Fody.targets" Condition="Exists('..\packages\Fody.6.3.0\build\Fody.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/packages.config
+++ b/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/packages.config
@@ -5,7 +5,7 @@
   <package id="Caliburn.Micro.AutofacBootstrap" version="3.0.1.17" targetFramework="net452" />
   <package id="Caliburn.Micro.Core" version="3.2.0" targetFramework="net452" />
   <package id="Costura.Fody" version="4.1.0" targetFramework="net452" />
-  <package id="Fody" version="6.2.0" targetFramework="net452" developmentDependency="true" />
+  <package id="Fody" version="6.3.0" targetFramework="net452" developmentDependency="true" />
   <package id="Hardcodet.NotifyIcon.Wpf" version="1.0.8" targetFramework="net452" />
   <package id="Microsoft.WindowsAPICodePack-Core" version="1.1.0.2" targetFramework="net452" />
   <package id="Microsoft.WindowsAPICodePack-Shell" version="1.1.0.0" targetFramework="net452" />


### PR DESCRIPTION
Hi!
I used Battery popup functionality some time, found and fixed some issues.
 
1) App crashed when "Show popup on low battery" enabled and controller is connecting.
2) The popup spams when "Show popup on low battery" enabled and controller has low level battery. Now shows every 5 min in the same case.
3) The toast message and popup displayed when controller is just connected but does not receive battery data (often case when using Xbox USB adapter)

Also updated Russian localization for all changes in testing branch.