### PR TITLE
Fixed tooltip on Win 11

### DIFF
--- a/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/SystemTrayView.xaml
+++ b/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/SystemTrayView.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:cal="http://www.caliburnproject.org"
-        xmlns:tb="http://www.hardcodet.net/taskbar"
+        xmlns:tb="clr-namespace:H.NotifyIcon;assembly=H.NotifyIcon.Wpf"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:xb1ControllerBatteryIndicator="clr-namespace:XB1ControllerBatteryIndicator"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator.csproj
+++ b/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator.csproj
@@ -98,8 +98,14 @@
     <Reference Include="Costura, Version=5.7.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Costura.Fody.5.7.0\lib\netstandard1.0\Costura.dll</HintPath>
     </Reference>
-    <Reference Include="Hardcodet.NotifyIcon.Wpf, Version=1.1.0.0, Culture=neutral, PublicKeyToken=682384a853a08aad, processorArchitecture=MSIL">
-      <HintPath>..\packages\Hardcodet.NotifyIcon.Wpf.1.1.0\lib\net45\Hardcodet.NotifyIcon.Wpf.dll</HintPath>
+    <Reference Include="H.GeneratedIcons.System.Drawing, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b9e9fbe9b6908adc, processorArchitecture=MSIL">
+      <HintPath>..\packages\H.GeneratedIcons.System.Drawing.2.1.0\lib\net462\H.GeneratedIcons.System.Drawing.dll</HintPath>
+    </Reference>
+    <Reference Include="H.NotifyIcon, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b9e9fbe9b6908adc, processorArchitecture=MSIL">
+      <HintPath>..\packages\H.NotifyIcon.2.1.0\lib\net462\H.NotifyIcon.dll</HintPath>
+    </Reference>
+    <Reference Include="H.NotifyIcon.Wpf, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b9e9fbe9b6908adc, processorArchitecture=MSIL">
+      <HintPath>..\packages\H.NotifyIcon.Wpf.2.1.0\lib\net462\H.NotifyIcon.Wpf.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>

--- a/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/packages.config
+++ b/XB1ControllerBatteryIndicator/XB1ControllerBatteryIndicator/packages.config
@@ -6,7 +6,9 @@
   <package id="Caliburn.Micro.Core" version="3.2.0" targetFramework="net48" />
   <package id="Costura.Fody" version="5.7.0" targetFramework="net48" developmentDependency="true" />
   <package id="Fody" version="6.8.0" targetFramework="net48" developmentDependency="true" />
-  <package id="Hardcodet.NotifyIcon.Wpf" version="1.1.0" targetFramework="net461" requireReinstallation="true" />
+  <package id="H.GeneratedIcons.System.Drawing" version="2.1.0" targetFramework="net48" />
+  <package id="H.NotifyIcon" version="2.1.0" targetFramework="net48" />
+  <package id="H.NotifyIcon.Wpf" version="2.1.0" targetFramework="net48" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net48" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net48" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net48" />


### PR DESCRIPTION
Recently installed Win 11 and checked the app on the new system. 
Updated tray icon package to fix tooltip mentioned in #76
Changed Hardcodet.NotifyIcon.Wpf (that is a bit dead now) to its fresh fork H.NotifyIcon.Wpf
![изображение](https://github.com/user-attachments/assets/5251e772-0bbe-4b57-b13e-42c5ff86c420)

@NiyaShy I tested the fix on Win 11 and all works fine, but has no ability to test it on Win 10. I would appreciate it if you could help me with this.